### PR TITLE
#17 각 도메인 엔티티 클래스 생성(수정)

### DIFF
--- a/backend/csrs/src/main/java/com/weart/csrs/domain/credit/Credit.java
+++ b/backend/csrs/src/main/java/com/weart/csrs/domain/credit/Credit.java
@@ -8,11 +8,11 @@ import javax.persistence.*;
 public class Credit {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "CREDIT_ID")
     private Long id;
 
     @OneToOne
     @JoinColumn(name = "SUCCESSFUL_BID_ID")
-    @Column(unique = true)
     private SuccessfulBid successfulBid;
 
     @Column(nullable = false)

--- a/backend/csrs/src/main/java/com/weart/csrs/domain/reliability/Reliability.java
+++ b/backend/csrs/src/main/java/com/weart/csrs/domain/reliability/Reliability.java
@@ -7,12 +7,12 @@ import javax.persistence.*;
 @Entity
 public class Reliability {
     @Id
+    @Column(name = "RELIABILITY_ID")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToOne
     @JoinColumn(name = "SUCCESSFUL_BID_ID")
-    @Column(unique = true)
     private SuccessfulBid successfulBid;
 
     @Column(nullable = false)

--- a/backend/csrs/src/main/java/com/weart/csrs/domain/successfulbid/SuccessfulBid.java
+++ b/backend/csrs/src/main/java/com/weart/csrs/domain/successfulbid/SuccessfulBid.java
@@ -3,7 +3,7 @@ package com.weart.csrs.domain.successfulbid;
 import com.weart.csrs.domain.bid.Bid;
 
 import javax.persistence.*;
-import java.util.Date;
+import java.time.LocalDateTime;
 
 @Entity
 public class SuccessfulBid {
@@ -14,11 +14,10 @@ public class SuccessfulBid {
 
     @OneToOne
     @JoinColumn(name = "BID_ID")
-    @Column(unique = true)
     private Bid bid;
 
     @Column(nullable = false)
-    private Date deadline;
+    private LocalDateTime deadline;
 
     @Column(nullable = false)
     private Boolean purchaseFlag;


### PR DESCRIPTION
- successfulbid 와 bid @onetoone 관계에서 참조 컬럼 unique 속성 삭제
- credit 과 successfulbid @onetoone 관계에서 참조 컬럼 unique 속성 삭제
- reliability와 successfulbid @onetoone 관계에서 참조 컬럼 unique 속성 삭제
- 날짜 데이터 타입 Date -> LocalDateTime으로 변경